### PR TITLE
fix issues with validations, error handling and using correct bot user

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -136,7 +136,7 @@ ifneq ($(HAS_WEBAPP),)
 	mkdir -p dist/$(PLUGIN_ID)/webapp
 	cp -r webapp/dist dist/$(PLUGIN_ID)/webapp/
 endif
-	cd dist && tar -cvzf $(BUNDLE_NAME) $(PLUGIN_ID)
+	cd dist && COPYFILE_DISABLE=1 tar -cvzf $(BUNDLE_NAME) $(PLUGIN_ID)
 
 	@echo plugin built at: dist/$(BUNDLE_NAME)
 

--- a/Makefile
+++ b/Makefile
@@ -136,7 +136,7 @@ ifneq ($(HAS_WEBAPP),)
 	mkdir -p dist/$(PLUGIN_ID)/webapp
 	cp -r webapp/dist dist/$(PLUGIN_ID)/webapp/
 endif
-	cd dist && COPYFILE_DISABLE=1 tar -cvzf $(BUNDLE_NAME) $(PLUGIN_ID)
+	cd dist && tar -cvzf $(BUNDLE_NAME) $(PLUGIN_ID)
 
 	@echo plugin built at: dist/$(BUNDLE_NAME)
 

--- a/plugin.json
+++ b/plugin.json
@@ -1,9 +1,9 @@
 {
-    "id": "com.darklord.plugin-google-drive",
+    "id": "com.mattermost-community.plugin-google-drive",
     "name": "Google Drive Plugin",
     "description": "This plugin allows you to integrate Google Drive to your Mattermost instance.",
-    "homepage_url": "https://github.com/darkLord/mattermost-plugin-google-drive",
-    "support_url": "https://github.com/mattermost/mattermost-plugin-google-drive/issues",
+    "homepage_url": "https://github.com/mattermost-community/mattermost-plugin-google-drive",
+    "support_url": "https://github.com/mattermost-community/mattermost-plugin-google-drive/issues",
     "icon_path": "assets/icon.svg",
     "min_server_version": "6.2.1",
     "server": {
@@ -20,7 +20,7 @@
     },
     "settings_schema": {
         "header": "The Google Drive plugin for Mattermost allows users to create, share files in Google drive and receive notifications for shared files and comments on files to stay up-to-date. \n \n Instructions for setup are [available here](https://github.com/mattermost-community/mattermost-plugin-google-drive#configuration).",
-        "footer": "* To report an issue, make a suggestion or a contribution, [check the repository](https://github.com/darkLord19/mattermost-plugin-google-drive).",
+        "footer": "* To report an issue, make a suggestion or a contribution, [check the repository](https://github.com/mattermost-community/mattermost-plugin-google-drive).",
         "settings": [
           {
             "key": "GoogleOAuthClientID",

--- a/server/plugin/api.go
+++ b/server/plugin/api.go
@@ -668,6 +668,7 @@ func (p *Plugin) handleFileUpload(c *Context, w http.ResponseWriter, r *http.Req
 	p.API.SendEphemeralPost(c.UserID, &model.Post{
 		Message:   "Successfully uploaded file in Google Drive.",
 		ChannelId: request.ChannelId,
+		UserId:    p.BotUserID,
 	})
 }
 
@@ -728,6 +729,7 @@ func (p *Plugin) handleAllFilesUpload(c *Context, w http.ResponseWriter, r *http
 	p.API.SendEphemeralPost(c.UserID, &model.Post{
 		Message:   "Successfully uploaded all files in Google Drive.",
 		ChannelId: request.ChannelId,
+		UserId:    p.BotUserID,
 	})
 }
 

--- a/server/plugin/disconnect.go
+++ b/server/plugin/disconnect.go
@@ -7,7 +7,7 @@ import (
 
 func (p *Plugin) handleDisconnect(c *plugin.Context, args *model.CommandArgs, _ []string) string {
 	var encryptedToken []byte
-	p.client.KV.Get(getUserTokenKey(args.UserId), &encryptedToken)
+	_ = p.client.KV.Get(getUserTokenKey(args.UserId), &encryptedToken)
 	if len(encryptedToken) == 0 {
 		return "There is no google account connected to your mattermost account."
 	}

--- a/server/plugin/disconnect.go
+++ b/server/plugin/disconnect.go
@@ -6,7 +6,12 @@ import (
 )
 
 func (p *Plugin) handleDisconnect(c *plugin.Context, args *model.CommandArgs, _ []string) string {
-	err := p.client.KV.Delete(args.UserId + "_token")
+	var encryptedToken []byte
+	p.client.KV.Get(getUserTokenKey(args.UserId), &encryptedToken)
+	if len(encryptedToken) == 0 {
+		return "There is no google account connected to your mattermost account."
+	}
+	err := p.client.KV.Delete(getUserTokenKey(args.UserId))
 	if err != nil {
 		p.client.Log.Error("Failed to disconnect google account", "error", err)
 		return "Encountered an error disconnecting Google account."


### PR DESCRIPTION
- If account is already disconnected or connected then return relevant message
- If user has already enabled or disabled activity notifications then send relevant messages
- Send file upload confirmation messages as plugin bot user instead of system user