### PR TITLE
File creation cleanup

### DIFF
--- a/server/plugin/api.go
+++ b/server/plugin/api.go
@@ -446,13 +446,13 @@ func (p *Plugin) handleFileCreation(c *Context, w http.ResponseWriter, r *http.R
 	err = p.handleFilePermissions(request.UserId, createdFileID, fileCreationParams.FileAccess, request.ChannelId, fileCreationParams.Name)
 	if err != nil {
 		p.API.LogError("Failed to modify file permissions", "err", err)
-		p.writeInteractiveDialogError(w, DialogErrorResponse{StatusCode: http.StatusInternalServerError})
+		p.writeInteractiveDialogError(w, DialogErrorResponse{Error: "File was successully created but file permissions failed to apply. Please contact your system administrator.", StatusCode: http.StatusInternalServerError})
 		return
 	}
 	err = p.sendFileCreatedMessage(request.ChannelId, createdFileID, request.UserId, fileCreationParams.Message, fileCreationParams.ShareInChannel, authToken)
 	if err != nil {
 		p.API.LogError("Failed to send file creation post", "err", err)
-		p.writeInteractiveDialogError(w, DialogErrorResponse{StatusCode: http.StatusInternalServerError})
+		p.writeInteractiveDialogError(w, DialogErrorResponse{Error: "File was successfully created but failed to share to the channel. Please contact your system administrator.", StatusCode: http.StatusInternalServerError})
 		return
 	}
 }

--- a/server/plugin/api.go
+++ b/server/plugin/api.go
@@ -446,7 +446,7 @@ func (p *Plugin) handleFileCreation(c *Context, w http.ResponseWriter, r *http.R
 	err = p.handleFilePermissions(request.UserId, createdFileID, fileCreationParams.FileAccess, request.ChannelId, fileCreationParams.Name)
 	if err != nil {
 		p.API.LogError("Failed to modify file permissions", "err", err)
-		p.writeInteractiveDialogError(w, DialogErrorResponse{Error: "File was successully created but file permissions failed to apply. Please contact your system administrator.", StatusCode: http.StatusInternalServerError})
+		p.writeInteractiveDialogError(w, DialogErrorResponse{Error: "File was successfully created but file permissions failed to apply. Please contact your system administrator.", StatusCode: http.StatusInternalServerError})
 		return
 	}
 	err = p.sendFileCreatedMessage(request.ChannelId, createdFileID, request.UserId, fileCreationParams.Message, fileCreationParams.ShareInChannel, authToken)

--- a/server/plugin/api.go
+++ b/server/plugin/api.go
@@ -443,7 +443,7 @@ func (p *Plugin) handleFileCreation(c *Context, w http.ResponseWriter, r *http.R
 		return
 	}
 
-	err = p.handleFilePermissions(request.UserId, createdFileID, fileCreationParams.FileAccess, request.ChannelId)
+	err = p.handleFilePermissions(request.UserId, createdFileID, fileCreationParams.FileAccess, request.ChannelId, fileCreationParams.Name)
 	if err != nil {
 		p.API.LogError("Failed to modify file permissions", "err", err)
 		p.writeInteractiveDialogError(w, DialogErrorResponse{StatusCode: http.StatusInternalServerError})

--- a/server/plugin/create.go
+++ b/server/plugin/create.go
@@ -232,7 +232,7 @@ func (p *Plugin) handleCreate(c *plugin.Context, args *model.CommandArgs, parame
 	about, err := srvV2.About.Get().Fields("domainSharingPolicy").Do()
 	if err != nil {
 		p.API.LogError("Failed to get user information", "err", err)
-		return "Failed to open file creation dialog"
+		return "Failed to open file creation dialog. Please contact your system administrator."
 	}
 
 	options := []*model.PostActionOptions{

--- a/server/plugin/create.go
+++ b/server/plugin/create.go
@@ -226,7 +226,7 @@ func (p *Plugin) handleCreate(c *plugin.Context, args *model.CommandArgs, parame
 	srvV2, err := driveV2.NewService(ctx, option.WithTokenSource(conf.TokenSource(ctx, authToken)))
 	if err != nil {
 		p.API.LogError("Failed to create drive client", "err", err)
-		return "Failed to open file creation dialog"
+		return "Failed to open file creation dialog. Please contact your system administrator."
 	}
 
 	about, err := srvV2.About.Get().Fields("domainSharingPolicy").Do()


### PR DESCRIPTION
#### Summary
- Hide sharing with "anyone" if your organisation has that permission disabled. I searched everywhere but I could not find a way to check this with the v3 SDK, they removed the `DomainSharingPolicy` field from the about endpoint. The approach to this permission in v3 seems to be that it will tell you if you don't have that permission if you try to apply it to a file, you cannot check beforehand. v2 has the field we need so I decided to use that SDK for that one check. v2 is not deprecated so I think it's safe to use this one time.
- When sharing a file with channel members it's possible that it will fail to share with some users if they are outside your domain but it should not cause the whole function to fail. I fixed that logic so that we inform the file creator, through a DM, about who didn't gain access.
- Better dialog error messages when file creation fails at a certain step.

#### Tickets
https://github.com/mattermost-community/mattermost-plugin-google-drive/issues/2
https://github.com/mattermost-community/mattermost-plugin-google-drive/issues/1