### PR TITLE
Cap unbounded calls to Google apis

### DIFF
--- a/server/plugin/api.go
+++ b/server/plugin/api.go
@@ -13,7 +13,6 @@ import (
 	"github.com/gorilla/mux"
 	mattermostModel "github.com/mattermost/mattermost/server/public/model"
 	"github.com/mattermost/mattermost/server/public/plugin"
-	"github.com/mattermost/mattermost/server/public/pluginapi"
 	"github.com/mattermost/mattermost/server/public/pluginapi/cluster"
 	"github.com/mattermost/mattermost/server/public/pluginapi/experimental/bot/logger"
 	"github.com/mattermost/mattermost/server/public/pluginapi/experimental/flow"
@@ -459,7 +458,6 @@ func (p *Plugin) handleDriveWatchNotifications(c *Context, w http.ResponseWriter
 	resourceState := r.Header.Get("X-Goog-Resource-State")
 	userID := r.URL.Query().Get("userID")
 
-	_, _ = p.Client.KV.Set("userID-"+userID, userID, pluginapi.SetExpiry(20))
 	if resourceState != "change" {
 		w.WriteHeader(http.StatusOK)
 		return

--- a/server/plugin/api.go
+++ b/server/plugin/api.go
@@ -576,17 +576,17 @@ func (p *Plugin) handleDriveWatchNotifications(c *Context, w http.ResponseWriter
 
 		modifiedTime, err := time.Parse(time.RFC3339, change.File.ModifiedTime)
 		if err != nil {
-			p.API.LogError("Failed to parse modified time", "err", err, "userID", userID)
+			p.API.LogError("Failed to parse modified time", "err", err, "userID", userID, "modifiedTime", change.File.ModifiedTime)
 			continue
 		}
 		lastChangeTime, err := time.Parse(time.RFC3339, change.Time)
 		if err != nil {
-			p.API.LogError("Failed to parse last change time", "err", err, "userID", userID)
+			p.API.LogError("Failed to parse last change time", "err", err, "userID", userID, "lastChangeTime", change.Time)
 			continue
 		}
 		viewedByMeTime, err := time.Parse(time.RFC3339, change.File.ViewedByMeTime)
 		if err != nil {
-			p.API.LogError("Failed to parse viewed by me time", "err", err, "userID", userID)
+			p.API.LogError("Failed to parse viewed by me time", "err", err, "userID", userID, "viewedByMeTime", change.File.ViewedByMeTime)
 			continue
 		}
 

--- a/server/plugin/create.go
+++ b/server/plugin/create.go
@@ -134,9 +134,9 @@ func (p *Plugin) handleFilePermissions(ctx context.Context, userID string, fileI
 	config := p.API.GetConfig()
 	var permissionError error
 
-	for _, permission := range permissions {
+	for i, permission := range permissions {
 		// Continue through the permissions loop when we encounter an error so we can inform the user who wasn't granted access.
-		if permissionError != nil {
+		if permissionError != nil || i > 60 {
 			usersWithoutAccesss = appendUsersWithoutAccessSlice(config, usersWithoutAccesss, userMap[permission.EmailAddress].Username, permission.EmailAddress)
 			continue
 		}

--- a/server/plugin/notifications.go
+++ b/server/plugin/notifications.go
@@ -202,6 +202,17 @@ func (p *Plugin) handleFileSharedNotification(file *drive.File, userID string) {
 	})
 }
 
+func (p *Plugin) handleMultipleActivitiesNotification(file *drive.File, userID string) {
+	p.createBotDMPost(userID, "There has been activity on this document", map[string]any{
+		"attachments": []any{map[string]any{
+			"title":       file.Name,
+			"title_link":  file.WebViewLink,
+			"footer":      "Google Drive for Mattermost",
+			"footer_icon": file.IconLink,
+		}},
+	})
+}
+
 func (p *Plugin) startDriveWatchChannel(userID string) error {
 	ctx := context.Background()
 	driveService, err := p.GoogleClient.NewDriveService(ctx, userID)


### PR DESCRIPTION
#### Summary
There are areas in the code where we could have ended up spamming Google with API requests. I added a cap to the number of calls each goroutine can make to the changes endpoint and the activity endpoint. It's unlikely we will ever end up in a situation where we have more than 5 pages of results but we have to cap it somehow. 

We also send one singular message if there is going to be more than 5 activities in a single file. This will prevent the user being spammed with too many notifications.

I also capped the number of people that you can share a file with to 60 because it is one call to Google per person added. The user will be informed of the people that didn't have the file shared with them. 