### PR TITLE
Drive plugin shouldn't share a file with the file creator

### DIFF
--- a/server/plugin/create.go
+++ b/server/plugin/create.go
@@ -85,7 +85,7 @@ func (p *Plugin) handleFilePermissions(ctx context.Context, userID string, fileI
 		{
 			users := p.getAllChannelUsers(channelID)
 			for _, user := range users {
-				if !user.IsBot {
+				if !user.IsBot && user.Id != userID {
 					permissions = append(permissions, &drive.Permission{
 						Role:         "reader",
 						EmailAddress: user.Email,
@@ -99,7 +99,7 @@ func (p *Plugin) handleFilePermissions(ctx context.Context, userID string, fileI
 		{
 			users := p.getAllChannelUsers(channelID)
 			for _, user := range users {
-				if !user.IsBot {
+				if !user.IsBot && user.Id != userID {
 					permissions = append(permissions, &drive.Permission{
 						Role:         "commenter",
 						EmailAddress: user.Email,
@@ -113,7 +113,7 @@ func (p *Plugin) handleFilePermissions(ctx context.Context, userID string, fileI
 		{
 			users := p.getAllChannelUsers(channelID)
 			for _, user := range users {
-				if !user.IsBot {
+				if !user.IsBot && user.Id != userID {
 					permissions = append(permissions, &drive.Permission{
 						Role:         "writer",
 						EmailAddress: user.Email,


### PR DESCRIPTION
Remove the current user from the share list because they already have access to the file. This reduces noise as the user would receive an email to say they shared a file with themselves