### PR TITLE
Safely dynamically generate URLs + misc fixes

### DIFF
--- a/server/plugin/api.go
+++ b/server/plugin/api.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	url2 "net/url"
+	"net/url"
 	"runtime/debug"
 	"strings"
 	"time"
@@ -601,7 +601,7 @@ func (p *Plugin) handleDriveWatchNotifications(c *Context, w http.ResponseWriter
 		}
 
 		driveActivityQuery := &driveactivity.QueryDriveActivityRequest{
-			ItemName: fmt.Sprintf("items/%s", url2.PathEscape(change.FileId)),
+			ItemName: fmt.Sprintf("items/%s", url.PathEscape(change.FileId)),
 		}
 
 		lastActivityTime, err := p.KVStore.GetLastActivityForFile(userID, change.FileId)
@@ -701,14 +701,14 @@ func (p *Plugin) openCommentReplyDialog(c *Context, w http.ResponseWriter, r *ht
 
 	commentID := request.Context["commentID"].(string)
 	fileID := request.Context["fileID"].(string)
-	url := fmt.Sprintf("%s/plugins/%s/api/v1/reply?fileID=%s&commentID=%s",
-		url2.PathEscape(*p.API.GetConfig().ServiceSettings.SiteURL),
-		url2.PathEscape(Manifest.Id),
-		url2.QueryEscape(fileID),
-		url2.QueryEscape(commentID))
+	urlStr := fmt.Sprintf("%s/plugins/%s/api/v1/reply?fileID=%s&commentID=%s",
+		url.PathEscape(*p.API.GetConfig().ServiceSettings.SiteURL),
+		url.PathEscape(Manifest.Id),
+		url.QueryEscape(fileID),
+		url.QueryEscape(commentID))
 	dialog := mattermostModel.OpenDialogRequest{
 		TriggerId: request.TriggerId,
-		URL:       url,
+		URL:       urlStr,
 		Dialog: mattermostModel.Dialog{
 			CallbackId:     "reply",
 			Title:          "Reply to comment",

--- a/server/plugin/command.go
+++ b/server/plugin/command.go
@@ -101,7 +101,7 @@ func parseCommand(input string) (command, action string, parameters []string) {
 			}
 
 			// ignore successive whitespaces that are outside of double quotes
-			if len(current) == 0 && !inQuotes {
+			if len(current) == 0 {
 				continue
 			}
 

--- a/server/plugin/command.go
+++ b/server/plugin/command.go
@@ -2,6 +2,7 @@ package plugin
 
 import (
 	"fmt"
+	url2 "net/url"
 	"strings"
 	"unicode"
 
@@ -185,7 +186,9 @@ func (p *Plugin) handleConnect(c *plugin.Context, args *model.CommandArgs, param
 		return "Encountered an error connecting to Google Drive."
 	}
 
-	return fmt.Sprintf("[Click here to link your Google account.](%s/plugins/%s/oauth/connect)", *siteURL, Manifest.Id)
+	return fmt.Sprintf("[Click here to link your Google account.](%s/plugins/%s/oauth/connect)",
+		*siteURL,
+		url2.PathEscape(Manifest.Id))
 }
 
 func (p *Plugin) handleDisconnect(c *plugin.Context, args *model.CommandArgs, _ []string) string {

--- a/server/plugin/command.go
+++ b/server/plugin/command.go
@@ -2,7 +2,7 @@ package plugin
 
 import (
 	"fmt"
-	url2 "net/url"
+	"net/url"
 	"strings"
 	"unicode"
 
@@ -94,7 +94,7 @@ func parseCommand(input string) (command, action string, parameters []string) {
 
 	for _, char := range input {
 		if unicode.IsSpace(char) {
-			// keep whitespaces that are inside double qoutes
+			// keep whitespaces that are inside double quotes
 			if inQuotes {
 				current += " "
 				continue
@@ -188,7 +188,7 @@ func (p *Plugin) handleConnect(c *plugin.Context, args *model.CommandArgs, param
 
 	return fmt.Sprintf("[Click here to link your Google account.](%s/plugins/%s/oauth/connect)",
 		*siteURL,
-		url2.PathEscape(Manifest.Id))
+		url.PathEscape(Manifest.Id))
 }
 
 func (p *Plugin) handleDisconnect(c *plugin.Context, args *model.CommandArgs, _ []string) string {

--- a/server/plugin/config/configuration.go
+++ b/server/plugin/config/configuration.go
@@ -9,7 +9,7 @@ import (
 	"github.com/pkg/errors"
 )
 
-// configuration captures the plugin's external configuration as exposed in the Mattermost server
+// Configuration captures the plugin's external configuration as exposed in the Mattermost server
 // configuration, as well as values computed from the configuration. Any public fields will be
 // deserialized from the Mattermost server configuration in OnConfigurationChange.
 //

--- a/server/plugin/create.go
+++ b/server/plugin/create.go
@@ -3,6 +3,7 @@ package plugin
 import (
 	"context"
 	"fmt"
+	"net/url"
 	"slices"
 	"strings"
 	"time"
@@ -143,7 +144,7 @@ func (p *Plugin) handleFilePermissions(ctx context.Context, userID string, fileI
 		_, err := driveService.CreatePermission(ctx, fileID, permission)
 		if err != nil {
 			usersWithoutAccesss = appendUsersWithoutAccessSlice(config, usersWithoutAccesss, userMap[permission.EmailAddress].Username, permission.EmailAddress)
-			// This error will occur if the user is not allowed to share the file with someone outside of their domain.
+			// This error will occur if the user is not allowed to share the file with someone outside their domain.
 			if strings.Contains(err.Error(), "shareOutNotPermitted") {
 				continue
 			}
@@ -176,9 +177,12 @@ func (p *Plugin) handleCreate(c *plugin.Context, args *model.CommandArgs, parame
 		return fmt.Sprintf("%s is not a valid create option", subcommand)
 	}
 
+	urlStr := fmt.Sprintf("/plugins/%s/api/v1/create?type=%s",
+		url.PathEscape(Manifest.Id),
+		url.QueryEscape(subcommand))
 	dialog := model.OpenDialogRequest{
 		TriggerId: args.TriggerId,
-		URL:       fmt.Sprintf("/plugins/%s/api/v1/create?type=%s", Manifest.Id, subcommand),
+		URL:       urlStr,
 		Dialog: model.Dialog{
 			CallbackId:     fmt.Sprintf("create_%s", subcommand),
 			Title:          fmt.Sprintf("Create a Google %s", cases.Title(language.English, cases.NoLower).String(subcommand)),

--- a/server/plugin/create.go
+++ b/server/plugin/create.go
@@ -131,19 +131,19 @@ func (p *Plugin) handleFilePermissions(ctx context.Context, userID string, fileI
 		return errors.Wrap(err, "failed to create Google Drive service")
 	}
 
-	usersWithoutAccesss := []string{}
+	usersWithoutAccess := []string{}
 	config := p.API.GetConfig()
 	var permissionError error
 
 	for i, permission := range permissions {
 		// Continue through the permissions loop when we encounter an error so we can inform the user who wasn't granted access.
 		if permissionError != nil || i > 60 {
-			usersWithoutAccesss = appendUsersWithoutAccessSlice(config, usersWithoutAccesss, userMap[permission.EmailAddress].Username, permission.EmailAddress)
+			usersWithoutAccess = appendUsersWithoutAccessSlice(config, usersWithoutAccess, userMap[permission.EmailAddress].Username, permission.EmailAddress)
 			continue
 		}
 		_, err := driveService.CreatePermission(ctx, fileID, permission)
 		if err != nil {
-			usersWithoutAccesss = appendUsersWithoutAccessSlice(config, usersWithoutAccesss, userMap[permission.EmailAddress].Username, permission.EmailAddress)
+			usersWithoutAccess = appendUsersWithoutAccessSlice(config, usersWithoutAccess, userMap[permission.EmailAddress].Username, permission.EmailAddress)
 			// This error will occur if the user is not allowed to share the file with someone outside their domain.
 			if strings.Contains(err.Error(), "shareOutNotPermitted") {
 				continue
@@ -152,21 +152,21 @@ func (p *Plugin) handleFilePermissions(ctx context.Context, userID string, fileI
 		}
 	}
 
-	if len(usersWithoutAccesss) > 0 {
-		p.createBotDMPost(userID, fmt.Sprintf("Failed to share file, \"%s\", with the following users: %s", fileName, strings.Join(usersWithoutAccesss, ", ")), nil)
+	if len(usersWithoutAccess) > 0 {
+		p.createBotDMPost(userID, fmt.Sprintf("Failed to share file, \"%s\", with the following users: %s", fileName, strings.Join(usersWithoutAccess, ", ")), nil)
 	}
 
 	return permissionError
 }
 
-func appendUsersWithoutAccessSlice(config *model.Config, usersWithoutAccesss []string, username string, email string) []string {
+func appendUsersWithoutAccessSlice(config *model.Config, usersWithoutAccess []string, username string, email string) []string {
 	if config.PrivacySettings.ShowEmailAddress == nil || !*config.PrivacySettings.ShowEmailAddress {
-		usersWithoutAccesss = append(usersWithoutAccesss, "@"+username)
+		usersWithoutAccess = append(usersWithoutAccess, "@"+username)
 	} else {
-		usersWithoutAccesss = append(usersWithoutAccesss, email)
+		usersWithoutAccess = append(usersWithoutAccess, email)
 	}
 
-	return usersWithoutAccesss
+	return usersWithoutAccess
 }
 
 func (p *Plugin) handleCreate(c *plugin.Context, args *model.CommandArgs, parameters []string) string {

--- a/server/plugin/flow.go
+++ b/server/plugin/flow.go
@@ -2,6 +2,7 @@ package plugin
 
 import (
 	"fmt"
+	"net/url"
 	"strings"
 
 	"github.com/gorilla/mux"
@@ -307,7 +308,9 @@ func (fm *FlowManager) submitOAuthConfig(f *flow.Flow, submitted map[string]inte
 
 func (fm *FlowManager) stepOAuthConnect() flow.Step {
 	connectPretext := "##### :white_check_mark: Connect your Google account"
-	connectURL := fmt.Sprintf("%s/plugins/%s/oauth/connect", *fm.client.Configuration.GetConfig().ServiceSettings.SiteURL, Manifest.Id)
+	connectURL := fmt.Sprintf("%s/plugins/%s/oauth/connect",
+		*fm.client.Configuration.GetConfig().ServiceSettings.SiteURL,
+		url.PathEscape(Manifest.Id))
 	connectText := fmt.Sprintf("Go [here](%s) to connect your account.", connectURL)
 	return flow.NewStep(stepOAuthConnect).
 		WithText(connectText).

--- a/server/plugin/notifications.go
+++ b/server/plugin/notifications.go
@@ -227,7 +227,10 @@ func (p *Plugin) startDriveWatchChannel(userID string) error {
 		return err
 	}
 
-	url, err := url.Parse(fmt.Sprintf("%s/plugins/%s/api/v1/webhook", *p.Client.Configuration.GetConfig().ServiceSettings.SiteURL, Manifest.Id))
+	urlStr := fmt.Sprintf("%s/plugins/%s/api/v1/webhook",
+		*p.Client.Configuration.GetConfig().ServiceSettings.SiteURL,
+		url.PathEscape(Manifest.Id))
+	url, err := url.Parse(urlStr)
 	if err != nil {
 		p.API.LogError("Failed to parse webhook url", "err", err)
 		return err

--- a/server/plugin/oauth.go
+++ b/server/plugin/oauth.go
@@ -2,6 +2,7 @@ package plugin
 
 import (
 	"fmt"
+	"net/url"
 	"sync"
 
 	"golang.org/x/oauth2"
@@ -36,11 +37,15 @@ func (p *Plugin) getOAuthConfig() *oauth2.Config {
 		"https://www.googleapis.com/auth/drive",
 	}
 
+	redirectUrl := fmt.Sprintf("%s/plugins/%s/oauth/complete",
+		url.PathEscape(*p.Client.Configuration.GetConfig().ServiceSettings.SiteURL),
+		url.PathEscape(Manifest.Id))
+
 	return &oauth2.Config{
 		ClientID:     config.GoogleOAuthClientID,
 		ClientSecret: config.GoogleOAuthClientSecret,
 		Scopes:       scopes,
-		RedirectURL:  fmt.Sprintf("%s/plugins/%s/oauth/complete", *p.Client.Configuration.GetConfig().ServiceSettings.SiteURL, Manifest.Id),
+		RedirectURL:  redirectUrl,
 		Endpoint:     google.Endpoint,
 	}
 }

--- a/server/plugin/oauth.go
+++ b/server/plugin/oauth.go
@@ -37,7 +37,7 @@ func (p *Plugin) getOAuthConfig() *oauth2.Config {
 		"https://www.googleapis.com/auth/drive",
 	}
 
-	redirectUrl := fmt.Sprintf("%s/plugins/%s/oauth/complete",
+	redirectURL := fmt.Sprintf("%s/plugins/%s/oauth/complete",
 		url.PathEscape(*p.Client.Configuration.GetConfig().ServiceSettings.SiteURL),
 		url.PathEscape(Manifest.Id))
 
@@ -45,7 +45,7 @@ func (p *Plugin) getOAuthConfig() *oauth2.Config {
 		ClientID:     config.GoogleOAuthClientID,
 		ClientSecret: config.GoogleOAuthClientSecret,
 		Scopes:       scopes,
-		RedirectURL:  redirectUrl,
+		RedirectURL:  redirectURL,
 		Endpoint:     google.Endpoint,
 	}
 }


### PR DESCRIPTION
- `url.PathEscape()` and `url.QueryEscape()` misc dynamically generated URLs
- Misc typos
	- "occureed" -> "occurred"
	- `usersWithoutAccesss` -> `usersWithoutAccess`
	- "qoutes" -> "quotes"
- Fix doc comments in `server/plugin/api.go`, `server/plugin/config/configuration.go`
- Fix comment language in `server/plugin/create.go` so IDE doesn't complain
- Remove redundant condition in if statement