### PR TITLE
Set a default for rate limit configs and check viewedbymetime exists

### DIFF
--- a/server/plugin/config/configuration.go
+++ b/server/plugin/config/configuration.go
@@ -55,6 +55,16 @@ func (c *Configuration) SetDefaults() (bool, error) {
 		changed = true
 	}
 
+	if c.QueriesPerMinute == 0 {
+		c.QueriesPerMinute = 12000
+		changed = true
+	}
+
+	if c.BurstSize == 0 {
+		c.BurstSize = 1000
+		changed = true
+	}
+
 	return changed, nil
 }
 


### PR DESCRIPTION
#### Summary
https://github.com/mattermost-community/mattermost-plugin-google-drive/issues/31

I also discovered a bug where the viewedbymetime might not be set if the user hasn't opened the document yet.