### PR TITLE
Fix accidental escaping of SiteURL

### DIFF
--- a/server/plugin/api.go
+++ b/server/plugin/api.go
@@ -702,7 +702,7 @@ func (p *Plugin) openCommentReplyDialog(c *Context, w http.ResponseWriter, r *ht
 	commentID := request.Context["commentID"].(string)
 	fileID := request.Context["fileID"].(string)
 	urlStr := fmt.Sprintf("%s/plugins/%s/api/v1/reply?fileID=%s&commentID=%s",
-		url.PathEscape(*p.API.GetConfig().ServiceSettings.SiteURL),
+		*p.API.GetConfig().ServiceSettings.SiteURL,
 		url.PathEscape(Manifest.Id),
 		url.QueryEscape(fileID),
 		url.QueryEscape(commentID))

--- a/server/plugin/oauth.go
+++ b/server/plugin/oauth.go
@@ -38,7 +38,7 @@ func (p *Plugin) getOAuthConfig() *oauth2.Config {
 	}
 
 	redirectURL := fmt.Sprintf("%s/plugins/%s/oauth/complete",
-		url.PathEscape(*p.Client.Configuration.GetConfig().ServiceSettings.SiteURL),
+		*p.Client.Configuration.GetConfig().ServiceSettings.SiteURL,
 		url.PathEscape(Manifest.Id))
 
 	return &oauth2.Config{


### PR DESCRIPTION
- Fix accidental escaping of SiteURL. This would have potentially turned `https://example.com` into `https:%2F%2Fexample.com`. 